### PR TITLE
Remove bld.bat

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
-if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 9da26af07a25431d8a3c412d4c8e78823c1298655d354f4f570ece1b995f8e74
 
 build:
-  number: 3
+  number: 4
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
The `bld.bat` files were a holdover from when the `meta.yaml`'s `build/script` field did not work on Windows. As that has long since been fixed in `conda-build`, simply drop this redundant file on Windows.