### PR TITLE
Release 0.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.2" %}
+{% set version = "0.5.2" %}
 
 package:
   name: cloudpickle
@@ -7,7 +7,7 @@ package:
 source:
   fn: cloudpickle-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/c/cloudpickle/cloudpickle-{{ version }}.tar.gz
-  sha256: faf15397039ab55f80c44f303c7201a57c660c3316f36101a67d7d973f8df358
+  sha256: b0e63dd89ed5285171a570186751bc9b84493675e99e12789e9a5dc5490ef554
 
 build:
   number: 0


### PR DESCRIPTION
```markdown
0.5.2
=====

- Fixed a regression: `AttributeError` when loading pickles that hold a
  reference to a dynamically defined class from the `__main__` module.
  ([issue #131]( https://github.com/cloudpipe/cloudpickle/issues/131)).

- Make it possible to pickle classes and functions defined in faulty
  modules that raise an exception when trying to look-up their attributes
  by name.


0.5.1
=====

- Fixed `cloudpickle.__version__`.

0.5.0
=====

- Use `pickle.HIGHEST_PROTOCOL` by default.
```

Also fixes https://github.com/conda-forge/cloudpickle-feedstock/issues/17